### PR TITLE
Fixed Undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,8 +20,8 @@ AC_PROG_CXX
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 LT_INIT([disable-static], [enable-silent-rules])
 AC_PROG_LIBTOOL
-CXXFLAGS="-O0 -g -std=c++0x -Wall"
-CFLAGS="-O0 -g"
+CXXFLAGS="-O0 -g -std=c++0x -Wall -lpthread"
+CFLAGS="-O0 -g -lpthread"
 AC_LANG([C++])
 
 PKG_CHECK_MODULES(UUID, uuid)


### PR DESCRIPTION
Hi,

```bash
[root@raminfp PParam]# make
make  all-recursive
make[1]: Entering directory '/root/PParam'
Making all in src
make[2]: Entering directory '/root/PParam/src'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/root/PParam/src'
Making all in examples
make[2]: Entering directory '/root/PParam/examples'
  CXXLD    nic
/usr/bin/ld: /root/PParam/src/.libs/libpparam.a(xdbengine.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
/usr/lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:421: recipe for target 'nic' failed
make[2]: *** [nic] Error 1
make[2]: Leaving directory '/root/PParam/examples'
Makefile:481: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/root/PParam'
Makefile:386: recipe for target 'all' failed
make: *** [all] Error 2
```